### PR TITLE
#5 fix PassPredictorTest which fails when run in Australian time zone and locale

### DIFF
--- a/src/main/java/uk/me/g4dpz/satellite/SatPassTime.java
+++ b/src/main/java/uk/me/g4dpz/satellite/SatPassTime.java
@@ -38,9 +38,12 @@
 package uk.me.g4dpz.satellite;
 
 import java.io.Serializable;
+import java.text.DateFormatSymbols;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.Objects;
+import java.util.TimeZone;
 
 public class SatPassTime implements Serializable {
 
@@ -57,8 +60,18 @@ public class SatPassTime implements Serializable {
     private static final String NEW_LINE = "\n";
     private static final String DEG_NL = " deg.\n";
 
-    private static final SimpleDateFormat TIME_FORMAT = new SimpleDateFormat("h:mm:ss a");
-    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("MMMMMM d, yyyy");
+    /** Format dates and times in UTC */
+    private static final TimeZone TZ = TimeZone.getTimeZone("UTC:UTC");
+
+    private static final SimpleDateFormat TIME_FORMAT;
+    private static final SimpleDateFormat DATE_FORMAT;
+
+    static {
+        TIME_FORMAT = new SimpleDateFormat("h:mm:ss a", DateFormatSymbols.getInstance(Locale.US));
+        TIME_FORMAT.setTimeZone(TZ);
+        DATE_FORMAT = new SimpleDateFormat("MMMMMM d, yyyy", DateFormatSymbols.getInstance(Locale.US));
+        DATE_FORMAT.setTimeZone(TZ);
+    }
 
     public SatPassTime(final Date startTime, final Date endTime, final String polePassed,
             final int aos, final int los, final double maxEl) {

--- a/src/test/java/uk/me/g4dpz/satellite/AbstractSatelliteTestBase.java
+++ b/src/test/java/uk/me/g4dpz/satellite/AbstractSatelliteTestBase.java
@@ -47,10 +47,14 @@ public abstract class AbstractSatelliteTestBase {
     static final GroundStationPosition GROUND_STATION =
             new GroundStationPosition(52.4670, -2.022, 200);
 
-    protected static final SimpleDateFormat TZ_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
-
-    /** The time at which we do all the calculations. */
+    /** Use UTC for all calculations and date formats. */
     static final TimeZone TZ = TimeZone.getTimeZone("UTC:UTC");
+
+    protected static final SimpleDateFormat TZ_FORMAT;
+    static {
+        TZ_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+        TZ_FORMAT.setTimeZone(TZ);
+    }
 
     /** Seconds per day. */
     static final long SECONDS_PER_DAY = 24 * 60 * 60;


### PR DESCRIPTION
- set UTC time zone for date formats in AbstractSatelliteTestBase
- set US locale for time format in SatPassTime.toString() so AM/PM are always capitalised
